### PR TITLE
Modified look of view notes and header

### DIFF
--- a/views/data.njk
+++ b/views/data.njk
@@ -21,24 +21,24 @@
           <td class = "govuk-table__cell">{{element.full_name}}</td>
           <td class = "govuk-table__cell" >{{element.title}}</td>
           <td class = "govuk-table__cell" >{{element.journal_entry}}</td>
-          {% set url = ["/data/", element.journal_entry_id] | join %}
+          {% set editPageURL = ["/data/", element.journal_entry_id] | join %}
           <td class = " govuk-table__cell">
-            <form method="PUT" action={{url}}>
-             <button class = "govuk-button" data-module = "govuk-button" type="submit" style="text-decoration: none; color: white;" >Edit</button>
-            </button>
-          </td>
-          {% set url = ["/data/", element.journal_entry_id, "?_method=DELETE"] | join %}
-          <td class = "govuk-table__cell">
-            <form method="POST" action={{url}}>
-              <button class = "govuk-button" data-module = "govuk-button" type="submit" style="text-decoration: none; color: white;" >Delete</button>
+            <form action={{editPageURL}}>
+              <button class = "govuk-button" data-module = "govuk-button" type="submit" style="text-decoration: none; color: white;">Edit</button>
             </form>
-          </td>
-        </tr>
-      {% endfor %}
-    </tbody>
-  </table>
+            </td>
+              {% set url = ["/data/", element.journal_entry_id, "?_method=DELETE"] | join %}
+              <td class = "govuk-table__cell">
+                <form method="POST" action={{url}}>
+                  <button class = "govuk-button" data-module = "govuk-button" type="submit" style="text-decoration: none; color: white;" >Delete</button>
+                </form>
+              </td>
+            </tr>
+          {% endfor %}
+        </tbody>
+      </table>
 
-  {{ govukTable({
+      {{ govukTable({
   caption: "Postgres Data Table - Nunjucks Macro Table",
   captionClasses: "govuk-table__caption--m",
   firstCellIsHeader: true,
@@ -61,4 +61,4 @@
   
 }) }}
 
-{% endblock %}
+    {% endblock %}

--- a/views/data.njk
+++ b/views/data.njk
@@ -3,34 +3,34 @@
 
 {% block section %}
 
-  <div style="font-size: 55px; margin-bottom: 20px">Postgres Data Table - HTML Table</div>
+  <div class = "govuk-heading-xl" style = "font-size: 2.5rem" >Here are your notes:</div>
 
-  <table style="border-collapse: separate; border: solid black 1px; border-spacing: 30px; margin-bottom: 20px;">
+  <table class = "govuk-table">
     <thead>
-      <tr style="text-align:center; font-weight: bold; font-size: 30px;">
+      <tr class = "govuk-table__header">
         <td>Journal Entry ID</td>
         <td>Full name</td>
         <td>Title</td>
         <td>Journal Entry</td>
       </tr>
     </thead>
-    <tbody>
+    <tbody class = "govuk-table__body">
       {% for element in rawData %}
-        <tr style="text-align:center; font-size: 25px;">
-          <td style="padding: 40px">{{element.journal_entry_id}}</td>
-          <td>{{element.full_name}}</td>
-          <td>{{element.title}}</td>
-          <td>{{element.journal_entry}}</td>
-          {% set editPageURL = ["/data/", element.journal_entry_id] | join %}
-          <td>
-            <button type="submit" style="padding: 10px; background-color: lightblue;">
-              <a style="text-decoration: none;" href={{editPageURL}}>Edit</a>
+        <tr class = "govuk-table__row">
+          <th scope = "row" class = "govuk-table__header">{{element.journal_entry_id}}</td>
+          <td class = "govuk-table__cell">{{element.full_name}}</td>
+          <td class = "govuk-table__cell" >{{element.title}}</td>
+          <td class = "govuk-table__cell" >{{element.journal_entry}}</td>
+          {% set url = ["/data/", element.journal_entry_id] | join %}
+          <td class = " govuk-table__cell">
+            <form method="PUT" action={{url}}>
+             <button class = "govuk-button" data-module = "govuk-button" type="submit" style="text-decoration: none; color: white;" >Edit</button>
             </button>
           </td>
           {% set url = ["/data/", element.journal_entry_id, "?_method=DELETE"] | join %}
-          <td>
+          <td class = "govuk-table__cell">
             <form method="POST" action={{url}}>
-              <button type="submit" style="padding: 10px; background-color: pink;">Delete</button>
+              <button class = "govuk-button" data-module = "govuk-button" type="submit" style="text-decoration: none; color: white;" >Delete</button>
             </form>
           </td>
         </tr>
@@ -56,7 +56,8 @@
       text: "Journal Entry"
     }
   ],
-  rows: transformedData
+  rows:
+    transformedData
   
 }) }}
 

--- a/views/layout.njk
+++ b/views/layout.njk
@@ -15,24 +15,29 @@
     <script src="/html5-shiv/html5shiv.js"></script>
   <![endif]-->
 {% endblock %}
+
+{% block header %}
+  {{ govukHeader({
+    homepageUrl: "/",
+    containerClasses: "app-width-container",
+    serviceName: " Journal Web-App",
+    serviceUrl: "/",
+    navigation: [
+      {
+        href: "/data",
+        text: "View Notes",
+        active: true
+      },
+      {
+        href: "/form",
+        text: "Add a new note"
+      }
+    ]
+  }) }}
+{% endblock %}
+
 {% block content %}
-  <h1 class="govuk-heading-xl">Journal Web-App</h1>
-  {{ govukBreadcrumbs({
-  items: [
-    {
-      text: "Home",
-      href: "/"
-    },
-    {
-      text: "Data",
-      href: "data"
-    },
-    {
-      text: "Form",
-      href: "form"
-    }
-  ]
-}) }}
+
 
   {% block section %}{% endblock %}
 

--- a/views/layout.njk
+++ b/views/layout.njk
@@ -25,8 +25,7 @@
     navigation: [
       {
         href: "/data",
-        text: "View Notes",
-        active: true
+        text: "View Notes"
       },
       {
         href: "/form",


### PR DESCRIPTION
I've updated the look of the Nav bar to use a different GOV.UK Header, and modified the HTML table and buttons on the view notes page to use some of the GOV.UK css classes, to give it a more GOV.UK look. I did remove the GOV.UK breadcrumbs but these can easily stay in if you'd like. 